### PR TITLE
wake up screen properly when transitioning to a remote client

### DIFF
--- a/TPLocalHost.m
+++ b/TPLocalHost.m
@@ -557,6 +557,9 @@ static TPLocalHost * _localHost = nil;
 		IORegistryEntrySetCFProperty(entry, CFSTR("IORequestIdle"), kCFBooleanFalse);
 		IOObjectRelease(entry);
 	}
+
+	// The previous code doesn't appear to work on Big Sur, but explicitly declaring user activity does. This should be cleaned up.
+	IOPMAssertionDeclareUserActivity(CFSTR("teleport waking screen"), kIOPMUserActiveLocal, &assertionID);
 }
 
 


### PR DESCRIPTION
Fixes #59 

It isn't clear to me why this worked previously. I suppose calling `IOPMAssertionCreate` with `kIOPMAssertionTypeNoDisplaySleep` would cause it to wake even when already asleep, but it's possible this is no longer true in Big Sur. Declaring a user activity will wake the screen reliably, but this section probably needs to be cleaned up in the future...