### PR TITLE
Redirect GitHub Pages root url to GitHub Repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
-gem "jekyll-github-metadata"
+gem 'jekyll-github-metadata'
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
     jekyll-github-metadata (2.13.0)
       jekyll (>= 3.4, < 5.0)
       octokit (~> 4.0, != 4.4.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -77,6 +79,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-github-metadata
+  jekyll-redirect-from
 
 BUNDLED WITH
    2.1.4

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,8 @@
 title: Teleport
 description: >-
   A Virtual KVM for macOS
-baseurl: "/teleport"
-url: "https://johndbritton.com"
+baseurl: '/teleport'
+url: 'https://johndbritton.com'
 plugins:
-  - "jekyll-github-metadata"
+  - 'jekyll-github-metadata'
+  - 'jekyll-redirect-from'

--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,5 @@ url: 'https://johndbritton.com'
 plugins:
   - 'jekyll-github-metadata'
   - 'jekyll-redirect-from'
+redirect_from:
+  json: false

--- a/index.md
+++ b/index.md
@@ -1,0 +1,4 @@
+---
+permalink: /
+redirect_to: https://github.com/johndbritton/teleport
+---


### PR DESCRIPTION
The root URL of the GitHub Pages site that's used for appcast feeds now redirects to the GitHub repository.