### PR TITLE
Check for updates using appcast powered by GitHub Releases

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -34,7 +34,7 @@
 	<key>NSUIElement</key>
 	<string>1</string>
 	<key>SUFeedURL</key>
-	<string>https://invalid.invalid</string>
+	<string>https://johndbritton.com/teleport/appcast/stable.xml</string>
 	<key>TPRevision</key>
 	<string>DEFINED_BY_GIT</string>
 </dict>

--- a/Info.plist
+++ b/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SUPublicEDKey</key>
+	<string>Mwd0NnDSn+FuwblRNQpLkpHpRNNnNx7Efk6Kz2xHc0A=</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>

--- a/TPMainController.m
+++ b/TPMainController.m
@@ -40,7 +40,7 @@ typedef CGError CGSError;
 extern CGSError	CPSGetFrontProcess( CPSProcessSerNum *pPSN);
 extern CGSError CPSSetFrontProcess( const CPSProcessSerNum *pPSN);
 
-#define VERSION_CHECK_URL @"https://invalid.invalid"
+#define VERSION_CHECK_URL @"https://johndbritton.com/teleport/appcast/stable.xml"
 
 static TPMainController * _mainController = nil;
 


### PR DESCRIPTION
I created a `stable` and `prerelease` appcast that's automatically generated from GitHub releases using Jekyll in https://github.com/johndbritton/teleport/pull/67.

This updates the app to point to that appcast feed.