### PR TITLE
Add edSignature to Appcast

### DIFF
--- a/_includes/appcast.inc
+++ b/_includes/appcast.inc
@@ -8,15 +8,25 @@
     {% for release in site.github.releases %}
       {% unless release.draft %}
         {% unless release.prerelease and page.stable %}
+          {% assign body_parts = release.body | split:'<!--' %}
+          {% assign description = body_parts | first %}
+          {% if body_parts.size == 2 %}
+            {% assign signature = body_parts | last | replace:'-->','' %}
+          {% else %}
+            {% assign signature = nil %}
+          {% endif %}
           <item>
             <title>{{ release.name }}</title>
-            <description><![CDATA[{{ release.body | markdownify }}]]></description>
+            <description><![CDATA[{{ description | markdownify }}]]></description>
             <pubDate>{{ release.published_at | date_to_rfc822 }}</pubDate>
             {% for asset in release.assets limit:1 %}
               {% assign version = release.tag_name | remove_first:'v' %}
               <enclosure
                   url="{{ asset.browser_download_url }}"
                   sparkle:version="{{ version }}"
+                  {% if signature %}
+                    sparkle:edSignature="{{ signature }}"
+                  {% endif %}
                   length="{{ asset.size }}"
                   type="application/octet-stream" />
             {% endfor %}


### PR DESCRIPTION
This adds a `edSignature` attribute to Appcasts by reading a trailing HTML comment from the description of a GitHub Release.

If a GitHub Release ends with a `<!--TOKEN-->`, token will be extracted and set to the `edSignature` attribute in the `<enclosure>` element of the Appcast: `<enclosure edSignature="TOKEN" />`.