### PR TITLE
Remove `build` job requirement from `update_appcast` workflow

### DIFF
--- a/.github/workflows/update_appcast.yml
+++ b/.github/workflows/update_appcast.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   update_appcast:
     name: Request GitHub Pages Build
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: GitHub Pages Build


### PR DESCRIPTION
Update Appcast is totally independent of other jobs now.