### PR TITLE
Sign releases for Sparkle auto-update

### DIFF
--- a/.github/workflows/draft_github_release.yml
+++ b/.github/workflows/draft_github_release.yml
@@ -32,6 +32,7 @@ jobs:
           CERT_KEYCHAIN_PATH: '/Users/runner/Library/Keychains/signing_temp.keychain-db'
           CERT_KEYCHAIN_PASSWORD: ${{ steps.import-certificates.output.keychain-password }}"
           GYM_EXPORT_TEAM_ID: ${{ secrets.BUILD_APPLE_TEAM_ID }}
+          SPARKLE_SIGNING_KEY_BASE64: ${{ secrets.BUILD_SPARKLE_SIGNING_KEY_BASE64 }}
           FL_GITHUB_RELEASE_API_TOKEN: ${{ secrets.BUILD_GITHUB_RELEASE_API_TOKEN }}
         with:
           lane: draft_github_release

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 gem 'dotenv'
 
+gem 'ed25519'
+
 gem 'fastlane'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
+    ed25519 (1.2.4)
     emoji_regex (3.2.1)
     excon (0.78.1)
     faraday (1.1.0)
@@ -175,6 +176,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
+  ed25519
   fastlane
 
 BUNDLED WITH

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,5 @@
 fastlane_require 'dotenv'
+fastlane_require 'ed25519'
 
 before_all do
   Dotenv.load('.env')
@@ -38,18 +39,22 @@ end
 lane :draft_github_release do
   tag = ENV['GITHUB_REF'].split('/').last
   UI.user_error!("Invalid tag string") && next unless tag =~ /^v\d+\.\d+\.\d+(-\w+\d*)?$/
+  sparkle_signing_key = Ed25519::SigningKey.new(Base64.decode64(ENV['SPARKLE_SIGNING_KEY_BASE64']))
   notarize_build
   zip(
     path: './build/teleport.app',
     output_path: "./build/teleport-#{tag}.zip"
   )
+  sparkle_signature = File.open(File.expand_path("../build/teleport-#{tag}.zip"), "rb") do |file|
+    Base64.encode64(sparkle_signing_key.sign(file.read)).chomp
+  end
   set_github_release(
     is_draft: true,
     repository_name: 'johndbritton/teleport',
     name: "Teleport #{tag}",
     tag_name: tag,
     upload_assets: "./build/teleport-#{tag}.zip",
-    description: 'TODO: add sparkele signature here',
+    description: "<!--#{sparkle_signature}-->",
     is_prerelease: tag.include?('-')
   )
 end


### PR DESCRIPTION
When creating a draft release from a tag, we now create an `ed25519` signature of the archive and store the signature in an HTML comment in the draft release description. We later use that signature to generate our appcast url for the sparkle auto-updater.